### PR TITLE
Prefetch stereo cubemaps

### DIFF
--- a/ReactVR/js/Views/Prefetch.js
+++ b/ReactVR/js/Views/Prefetch.js
@@ -82,7 +82,7 @@ export default class RCTPrefetch extends RCTBaseView {
   static uriKey(uri) {
     if (Array.isArray(uri)) {
       // Cubemap, check proper format
-      if (uri.length === 6) {
+      if (uri.length === 6 || uri.length === 12) {
         const urls = uri.map(RCTPrefetch.getUri);
         return urls.join(',');
       } else {

--- a/ReactVR/js/Views/Prefetch.js
+++ b/ReactVR/js/Views/Prefetch.js
@@ -54,7 +54,7 @@ export default class RCTPrefetch extends RCTBaseView {
 
     if (Array.isArray(uri)) {
       // Cubemap, check proper format
-      if (uri.length !== 6 || !uri[0].uri) {
+      if ((uri.length !== 6 && uri.length !== 12) || !uri[0].uri) {
         console.warn(
           'Prefetch expected cubemap source in format [{uri: http..}, {uri: http..}, ... ]'
         );


### PR DESCRIPTION
Official PR: https://github.com/facebook/react-vr/pull/389

Currently `Prefetch` only supports the 6 image mono cubemaps, while `Pano` supports both mono cubemaps and 12 image stereo cubemaps.

Same logic as per `Pano` component: https://github.com/facebook/react-vr/blob/055cfdfde43d7d110db0ab0bafa8d91c6da02024/ReactVR/js/Views/Pano.js#L290

Also noticed `Prefetch.uriKey` only uses first 6 images for keying stereo cubemaps, updated so it uses all 12 for keying.